### PR TITLE
swift-testing migration

### DIFF
--- a/Sources/InfrastructureNetwork/Implementations/NetworkProviderImplementation.swift
+++ b/Sources/InfrastructureNetwork/Implementations/NetworkProviderImplementation.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NetworkProviderImplementation {
         private let logger: NetworkLogger?
         private let networkSession: NetworkSession
-        
+
         public init(
                 logger: NetworkLogger? = nil,
                 networkSession: NetworkSession
@@ -16,8 +16,8 @@ public final class NetworkProviderImplementation {
 extension NetworkProviderImplementation: NetworkProvider {
         public func request<
                 ResponseType: Decodable,
-                EndpointType: Endpoint>
-        (_ endpoint: EndpointType) async throws(NetworkProviderError) -> ResponseType {
+                EndpointType: Endpoint
+        >(_ endpoint: EndpointType) async throws(NetworkProviderError) -> ResponseType {
                 do {
                         let urlRequest = try prepareUrlRequest(for: endpoint)
                         logger?.log(request: urlRequest)
@@ -26,9 +26,9 @@ extension NetworkProviderImplementation: NetworkProvider {
                                 response: urlResponse,
                                 data: data
                         )
-                        
+
                         try validate(urlResponse: urlResponse, data: data)
-                        
+
                         do {
                                 return try JSONDecoder()
                                         .decode(
@@ -98,7 +98,7 @@ extension NetworkProviderImplementation {
 
                 return urlRequest
         }
-        
+
         private func validate(
                 urlResponse: URLResponse,
                 data: Data
@@ -106,29 +106,29 @@ extension NetworkProviderImplementation {
                 guard let httpResponse = urlResponse as? HTTPURLResponse else {
                         throw NetworkProviderError.nonHTTResponse
                 }
-                
+
                 switch httpResponse.statusCode {
                         case 404:
                                 throw NetworkProviderError.notFound
-                                
+
                         case 403:
                                 throw NetworkProviderError.unauthorized
-                                
+
                         case 408:
                                 throw NetworkProviderError.timeout
-                                
+
                         case 400...499:
                                 throw NetworkProviderError.invalidRequest
-                                
+
                         case 500...599:
                                 throw NetworkProviderError.serverError
-                                
+
                         case 200...299:
                                 guard !data.isEmpty else {
                                         throw NetworkProviderError.noData
                                 }
                                 break
-                                
+
                         default:
                                 throw NetworkProviderError.other
                 }

--- a/Sources/InfrastructureNetwork/Protocols/NetworkProvider.swift
+++ b/Sources/InfrastructureNetwork/Protocols/NetworkProvider.swift
@@ -5,5 +5,5 @@ public protocol NetworkProvider {
         func request<
                 ResponseType: Decodable,
                 EndpointType: Endpoint
-        >(_ endpoint: EndpointType) async throws (NetworkProviderError)-> ResponseType
+        >(_ endpoint: EndpointType) async throws(NetworkProviderError) -> ResponseType
 }

--- a/Tests/InfrastructureNetworkTests/Fakes/NetworkSessionFake.swift
+++ b/Tests/InfrastructureNetworkTests/Fakes/NetworkSessionFake.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 @testable import InfrastructureNetwork
 
 final class NetworkSessionFake: NetworkSession {

--- a/Tests/InfrastructureNetworkTests/NetworkProviderImplementationTests.swift
+++ b/Tests/InfrastructureNetworkTests/NetworkProviderImplementationTests.swift
@@ -1,7 +1,7 @@
-@testable import InfrastructureNetwork
 import Foundation
 import Testing
 
+@testable import InfrastructureNetwork
 
 @Suite("NetworkProviderImplementation Error Handling")
 struct NetworkProviderImplementationErrorHandlingTests {
@@ -26,7 +26,7 @@ struct NetworkProviderImplementationErrorHandlingTests {
                         urlResponseToReturn: returnURLResponse
                 )
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
@@ -36,12 +36,12 @@ struct NetworkProviderImplementationErrorHandlingTests {
                         #expect(error == expectedError)
                 }
         }
-        
+
         @Test("When decoding fails, network provider throws parsing error")
         func testFailDecoding() async {
                 // Given
                 let sut = NetworkProviderImplementation(networkSession: NetworkSessionSpy.fixture())
-                
+
                 do {
                         // When
                         let _: StubInstance2 = try await sut.request(StubEndpoint.getEndpoint)
@@ -51,13 +51,13 @@ struct NetworkProviderImplementationErrorHandlingTests {
                         #expect(error == NetworkProviderError.parsingError)
                 }
         }
-        
+
         @Test("When network sessions throws not connected to internet, network provider throws no network connection")
         func testNoNetworkConnection() async {
                 // Given
                 let networkSessionSpy = NetworkSessionSpy(errorToThrow: URLError(.notConnectedToInternet))
                 let networkProvider = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await networkProvider.request(StubEndpoint.getEndpoint)
@@ -67,14 +67,14 @@ struct NetworkProviderImplementationErrorHandlingTests {
                         #expect(error == NetworkProviderError.noNetworkConnection)
                 }
         }
-        
+
         @Test("When network sesions throws other error, network provider throws same error")
         func testOtherError() async {
                 // Given
                 let expectedError = NetworkProviderError.other
                 let networkSessionSpy = NetworkSessionSpy(errorToThrow: expectedError)
                 let networkProvider = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await networkProvider.request(StubEndpoint.getEndpoint)
@@ -84,7 +84,7 @@ struct NetworkProviderImplementationErrorHandlingTests {
                         #expect(error == expectedError)
                 }
         }
-        
+
         @Test("When API returns non HTTP response, network provider throws same error")
         func testNonHTTPResponse() async {
                 // Given
@@ -93,7 +93,7 @@ struct NetworkProviderImplementationErrorHandlingTests {
                         urlResponseToReturn: URLResponse()
                 )
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
@@ -103,13 +103,13 @@ struct NetworkProviderImplementationErrorHandlingTests {
                         #expect(error == NetworkProviderError.nonHTTResponse)
                 }
         }
-        
+
         @Test("When API response is in range 200...299 and no data is returned, network provider throws no data")
         func test200RangeNoData() async {
                 // Given
                 let networkSessionSpy = NetworkSessionSpy.fixture(dataToReturn: Data())
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
@@ -119,12 +119,12 @@ struct NetworkProviderImplementationErrorHandlingTests {
                         #expect(error == NetworkProviderError.noData)
                 }
         }
-        
+
         @Test("When URL is invalid, network provider throws same error")
         func testInvalidURL() async {
                 // Given
                 let networkProvider = NetworkProviderImplementation(networkSession: NetworkSessionFake())
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await networkProvider.request(StubEndpoint.invalidURLEndpoint)
@@ -144,27 +144,27 @@ struct NetworkProviderImplementationProcessingTests {
                 let endpoint = StubEndpoint.getEndpoint
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let networkProvider = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await networkProvider.request(endpoint)
                         let _: StubInstance1 = try await networkProvider.request(endpoint)
                         let _: StubInstance1 = try await networkProvider.request(endpoint)
-                        
+
                         // Then
                         #expect(networkSessionSpy.dataForRequestMethodWasCalledXTimes == 3)
                 } catch let error {
                         Issue.record("Expected success, got \(error) instead.")
                 }
         }
-        
+
         @Test("When endpoint body is plain, request must not have body or parameters")
         func testPlainEndpointBody() async {
                 // Given
                 let endpoint = StubEndpoint.getEndpoint
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(endpoint)
@@ -176,7 +176,7 @@ struct NetworkProviderImplementationProcessingTests {
                         Issue.record("Expected success, got \(error) instead.")
                 }
         }
-        
+
         @Test("When endpoint body is encodable, request has JSON headers and body")
         func testEncodableBody() async {
                 // Given
@@ -184,15 +184,15 @@ struct NetworkProviderImplementationProcessingTests {
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
                 let encodableRequest = StubRequest.fixture()
                 let endpoint = StubEndpoint.encodableBodyEndpoint(encodableRequest)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(endpoint)
-                        
+
                         // Then
                         let receivedURLRequest = networkSessionSpy.receivedURLRequest
                         #expect(receivedURLRequest?.url?.path() == endpoint.path)
-                        
+
                         if let receivedHTTPBody = receivedURLRequest?.httpBody {
                                 if let receivedBody = try? JSONDecoder().decode(StubRequest.self, from: receivedHTTPBody) {
                                         #expect(receivedBody == encodableRequest)
@@ -202,13 +202,13 @@ struct NetworkProviderImplementationProcessingTests {
                         } else {
                                 Issue.record("Expected HTTPBody, got nil instead.")
                         }
-                        
+
                         #expect(receivedURLRequest?.value(forHTTPHeaderField: HTTPHeader.Key.contentType) == HTTPHeader.Value.applicationJSON)
                 } catch {
                         Issue.record("Expected success, got \(error) instead.")
                 }
         }
-        
+
         @Test("When endpoint body is query parameter, request has correct query items")
         func testQueryParameter() async {
                 // Given
@@ -221,16 +221,16 @@ struct NetworkProviderImplementationProcessingTests {
                         "parameterWithNoValue": nil,
                 ]
                 let expectedQueryParameters =
-                queryParameters
+                        queryParameters
                         .map(URLQueryItem.init)
                         .sorted(by: queryItemSorting)
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.queryParametersEndpoint(queryParameters))
-                        
+
                         if let receivedURLRequest = networkSessionSpy.receivedURLRequest {
                                 // Then
                                 let receivedQueryParameters = getQueryItems(from: receivedURLRequest)
@@ -243,7 +243,7 @@ struct NetworkProviderImplementationProcessingTests {
                         Issue.record("doesn't matter error \(error)")
                 }
         }
-        
+
         @Test("When endpoint has custom headers, request has correct headers")
         func testHeaders() async {
                 // Given
@@ -253,11 +253,11 @@ struct NetworkProviderImplementationProcessingTests {
                 let expectedHeaders = StubEndpoint.queryParametersEndpoint(queryParameters).headers
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.queryParametersEndpoint(queryParameters))
-                        
+
                         // Then
                         let receivedURLRequest = networkSessionSpy.receivedURLRequest
                         #expect(receivedURLRequest?.allHTTPHeaderFields == expectedHeaders)
@@ -265,7 +265,7 @@ struct NetworkProviderImplementationProcessingTests {
                         Issue.record("Expected success, got error \(error) instead.")
                 }
         }
-        
+
         @Test("When endpoint has custom path, request has correct path")
         func testCustomPath() async {
                 // Given
@@ -275,11 +275,11 @@ struct NetworkProviderImplementationProcessingTests {
                 let endpoint = StubEndpoint.queryParametersEndpoint(queryParameters)
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(endpoint)
-                        
+
                         // Then
                         let receivedURLRequest = networkSessionSpy.receivedURLRequest
                         #expect(receivedURLRequest?.url?.path() == endpoint.path)
@@ -287,20 +287,20 @@ struct NetworkProviderImplementationProcessingTests {
                         Issue.record("Expected success, got error \(error) instead.")
                 }
         }
-        
+
         @Test("Network Provider sets correct HTTP method from endpoint in URL request")
         func testHTTPMethod() async {
                 // Given
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-                
+
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
                         let receivedGetURLRequest = networkSessionSpy.receivedURLRequest
                         let _: StubInstance1 = try await sut.request(StubEndpoint.postEndpoint)
                         let receivedPostURLRequest = networkSessionSpy.receivedURLRequest
-                        
+
                         // Then
                         #expect(receivedGetURLRequest?.httpMethod == HTTPMethod.get.rawValue)
                         #expect(receivedPostURLRequest?.httpMethod == HTTPMethod.post.rawValue)
@@ -308,17 +308,17 @@ struct NetworkProviderImplementationProcessingTests {
                         Issue.record("Expected success, got error \(error) instead.")
                 }
         }
-        
+
         @Test("Network provider decodes expected response")
         func testDecodeResponse() async {
                 // Given
                 let expectedInstance = StubInstance1.fixture()
                 let sut = NetworkProviderImplementation(networkSession: NetworkSessionSpy.fixture())
-                
+
                 do {
                         // When
                         let receivedInstance: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-                        
+
                         // Then
                         #expect(receivedInstance == expectedInstance)
                 } catch {
@@ -340,7 +340,7 @@ extension NetworkProviderImplementationProcessingTests {
                 else {
                         return .init()
                 }
-                
+
                 return queryItems
         }
 }

--- a/Tests/InfrastructureNetworkTests/NetworkProviderImplementationTests.swift
+++ b/Tests/InfrastructureNetworkTests/NetworkProviderImplementationTests.swift
@@ -1,313 +1,216 @@
-import XCTest
 @testable import InfrastructureNetwork
+import Foundation
+import Testing
 
-final class NetworkProviderImplementationTests: XCTestCase {
-        // MARK: - Test cases
-        func test_whenDecodingFails_networkProviderThrowsNetworkErrorParsingError() async {
+
+@Suite("NetworkProviderImplementation Error Handling")
+struct NetworkProviderImplementationErrorHandlingTests {
+        @Test(
+                "When network session throws HTTPURLResponse with status code, repository maps to expected error",
+                arguments: [
+                        (HTTPURLResponse.fixture(statusCode: 403), NetworkProviderError.unauthorized),
+                        (HTTPURLResponse.fixture(statusCode: 404), NetworkProviderError.notFound),
+                        (HTTPURLResponse.fixture(statusCode: 408), NetworkProviderError.timeout),
+                        (HTTPURLResponse.fixture(statusCode: 499), NetworkProviderError.invalidRequest),
+                        (HTTPURLResponse.fixture(statusCode: 599), NetworkProviderError.serverError),
+                        (HTTPURLResponse.fixture(statusCode: 1000), NetworkProviderError.other),
+                ]
+        )
+        func testErrorMapping(
+                returnURLResponse: HTTPURLResponse,
+                expectedError: NetworkProviderError
+        ) async {
+                // Given
+                let networkSessionSpy = NetworkSessionSpy(
+                        dataToReturn: Data(),
+                        urlResponseToReturn: returnURLResponse
+                )
+                let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
+                
+                do {
+                        // When
+                        let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
+                        Issue.record("Expected \(expectedError.testDescription), got success instead.")
+                } catch {
+                        // Then
+                        #expect(error == expectedError)
+                }
+        }
+        
+        @Test("When decoding fails, network provider throws parsing error")
+        func testFailDecoding() async {
                 // Given
                 let sut = NetworkProviderImplementation(networkSession: NetworkSessionSpy.fixture())
-
+                
                 do {
                         // When
                         let _: StubInstance2 = try await sut.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.parsingError.testDescription), got success instead.")
+                        Issue.record("Expected \(NetworkProviderError.parsingError.testDescription), got success instead.")
                 } catch {
                         // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.parsingError
-                        )
+                        #expect(error == NetworkProviderError.parsingError)
                 }
         }
-
-        func test_whenNetworkSessionThrowsNotConnectedToInternet_networkProviderThrowsNoNetworkConnection() async {
+        
+        @Test("When network sessions throws not connected to internet, network provider throws no network connection")
+        func testNoNetworkConnection() async {
                 // Given
                 let networkSessionSpy = NetworkSessionSpy(errorToThrow: URLError(.notConnectedToInternet))
                 let networkProvider = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await networkProvider.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.noNetworkConnection.testDescription), got success instead.")
+                        Issue.record("Expected \(NetworkProviderError.noNetworkConnection.testDescription), got success instead.")
                 } catch {
                         // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.noNetworkConnection
-                        )
+                        #expect(error == NetworkProviderError.noNetworkConnection)
                 }
         }
-
-        func test_whenNetworkSessionThrowsNonHandledError_networkProviderThrowsSameError() async {
+        
+        @Test("When network sesions throws other error, network provider throws same error")
+        func testOtherError() async {
                 // Given
                 let expectedError = NetworkProviderError.other
                 let networkSessionSpy = NetworkSessionSpy(errorToThrow: expectedError)
                 let networkProvider = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await networkProvider.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.other.localizedDescription), got success instead.")
+                        Issue.record("Expected \(NetworkProviderError.other.localizedDescription), got success instead.")
                 } catch {
                         // Then
-                        XCTAssertEqual(
-                                error,
-                                expectedError
-                        )
+                        #expect(error == expectedError)
                 }
         }
-
-        func test_whenAPIRespondsNonHandledStatusCode_networkProviderThrowsNetworkErrorOther() async {
-                // Given
-                let networkSessionSpy = NetworkSessionSpy(
-                        dataToReturn: Data(),
-                        urlResponseToReturn: HTTPURLResponse.fixture(statusCode: 1000)
-                )
-                let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
-                do {
-                        // When
-                        let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.other.testDescription), got success instead.")
-                } catch {
-                        // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.other
-                        )
-                }
-        }
-
-        func test_whenAPIRespondsNonHTTPResponse_networkProviderThrowsNetworkErrorNonHTTPResponse() async {
+        
+        @Test("When API returns non HTTP response, network provider throws same error")
+        func testNonHTTPResponse() async {
                 // Given
                 let networkSessionSpy = NetworkSessionSpy(
                         dataToReturn: Data(),
                         urlResponseToReturn: URLResponse()
                 )
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.nonHTTResponse.testDescription), got success instead.")
+                        Issue.record("Expected \(NetworkProviderError.nonHTTResponse.testDescription), got success instead.")
                 } catch {
                         // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.nonHTTResponse
-                        )
+                        #expect(error == NetworkProviderError.nonHTTResponse)
                 }
         }
-
-        func test_whenAPIResponds403_networkProviderThrowsNetworkErrorUnauthorized() async {
-                // Given
-                let networkSessionSpy = NetworkSessionSpy.fixture(urlResponseToReturn: HTTPURLResponse.fixture(statusCode: 403))
-                let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
-                do {
-                        // When
-                        let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.unauthorized.testDescription), got success instead.")
-                } catch {
-                        // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.unauthorized
-                        )
-                }
-        }
-
-        func test_whenAPIResponds404_networkProviderThrowsNetworkErrorNotFound() async {
-                // Given
-                let networkSessionSpy = NetworkSessionSpy.fixture(urlResponseToReturn: HTTPURLResponse.fixture(statusCode: 404))
-                let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
-                do {
-                        // When
-                        let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.notFound.testDescription), got success instead.")
-                } catch {
-                        // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.notFound
-                        )
-                }
-        }
-
-        func test_whenAPIResponds408OrTimeout_networkProviderThrowsNetworkErrorTimeout() async {
-                // Given
-                let networkSessionSpy = NetworkSessionSpy.fixture(urlResponseToReturn: HTTPURLResponse.fixture(statusCode: 408))
-                let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
-                do {
-                        // When
-                        let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.timeout.testDescription), got success instead.")
-                } catch {
-                        // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.timeout
-                        )
-                }
-        }
-
-        func test_whenAPIRespondsRange400499_networkProviderThrowsNetworkErrorInvalidRequest() async {
-                // Given
-                let networkSessionSpy = NetworkSessionSpy.fixture(urlResponseToReturn: HTTPURLResponse.fixture(statusCode: 499))
-                let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
-                do {
-                        // When
-                        let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.invalidRequest.testDescription), got success instead.")
-                } catch {
-                        // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.invalidRequest
-                        )
-                }
-        }
-
-        func test_whenAPIRespondsRange500599_networkProviderThrowsNetworkErrorServerError() async {
-                // Given
-                let networkSessionSpy = NetworkSessionSpy.fixture(urlResponseToReturn: HTTPURLResponse.fixture(statusCode: 599))
-                let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
-                do {
-                        // When
-                        let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.serverError.testDescription), got success instead.")
-                } catch {
-                        // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.serverError
-                        )
-                }
-        }
-
-        func test_whenAPIRespondsRange200299AndNoData_networkProviderThrowsNetworkErrorNoData() async {
+        
+        @Test("When API response is in range 200...299 and no data is returned, network provider throws no data")
+        func test200RangeNoData() async {
                 // Given
                 let networkSessionSpy = NetworkSessionSpy.fixture(dataToReturn: Data())
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.noData.testDescription), got success instead.")
+                        Issue.record("Expected \(NetworkProviderError.noData.testDescription), got success instead.")
                 } catch {
                         // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.noData
-                        )
+                        #expect(error == NetworkProviderError.noData)
                 }
         }
-
-        func test_whenURLIsInvalid_providerThrowsNetworkErrorInvalidURL() async {
+        
+        @Test("When URL is invalid, network provider throws same error")
+        func testInvalidURL() async {
                 // Given
                 let networkProvider = NetworkProviderImplementation(networkSession: NetworkSessionFake())
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await networkProvider.request(StubEndpoint.invalidURLEndpoint)
-                        XCTFail("Expected \(NetworkProviderError.invalidURL.testDescription) thrown, got success instead.")
+                        Issue.record("Expected \(NetworkProviderError.invalidURL.testDescription) thrown, got success instead.")
                 } catch {
                         // Then
-                        XCTAssertEqual(
-                                error,
-                                NetworkProviderError.invalidURL
-                        )
+                        #expect(error == NetworkProviderError.invalidURL)
                 }
         }
+}
 
-        func test_whenProviderMakesSeveralRequests_usesTheSameNetworkSessionInstance() async {
+@Suite("NetworkProviderImplementation Processing")
+struct NetworkProviderImplementationProcessingTests {
+        @Test("When network provider makes several requests, it uses the same network session instance")
+        func testSameNetworkSessionInstance() async {
                 // Given
                 let endpoint = StubEndpoint.getEndpoint
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let networkProvider = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await networkProvider.request(endpoint)
                         let _: StubInstance1 = try await networkProvider.request(endpoint)
                         let _: StubInstance1 = try await networkProvider.request(endpoint)
-
+                        
                         // Then
-                        XCTAssertEqual(
-                                networkSessionSpy.dataForRequestMethodWasCalledXTimes,
-                                3
-                        )
+                        #expect(networkSessionSpy.dataForRequestMethodWasCalledXTimes == 3)
                 } catch let error {
-                        XCTFail("Expected success, got \(error) instead.")
+                        Issue.record("Expected success, got \(error) instead.")
                 }
         }
-
-        func test_whenEndpointBodyIsPlain_requestMustNotHaveBodyOrParameters() async {
+        
+        @Test("When endpoint body is plain, request must not have body or parameters")
+        func testPlainEndpointBody() async {
                 // Given
                 let endpoint = StubEndpoint.getEndpoint
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(endpoint)
                         let receivedURLRequest = networkSessionSpy.receivedURLRequest
-                        XCTAssertEqual(
-                                receivedURLRequest?.url?.path(),
-                                endpoint.path
-                        )
-                        XCTAssertNil(receivedURLRequest?.httpBody)
-                        XCTAssertNil(receivedURLRequest?.value(forHTTPHeaderField: HTTPHeader.Key.contentType))
+                        #expect(receivedURLRequest?.url?.path() == endpoint.path)
+                        #expect(receivedURLRequest?.httpBody == nil)
+                        #expect(receivedURLRequest?.value(forHTTPHeaderField: HTTPHeader.Key.contentType) == nil)
                 } catch {
-                        XCTFail("Expected success, got \(error) instead.")
+                        Issue.record("Expected success, got \(error) instead.")
                 }
         }
-
-        func test_whenEndpointBodyIsEncodable_requestHasJSONHeadersAndBody() async {
+        
+        @Test("When endpoint body is encodable, request has JSON headers and body")
+        func testEncodableBody() async {
                 // Given
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
                 let encodableRequest = StubRequest.fixture()
                 let endpoint = StubEndpoint.encodableBodyEndpoint(encodableRequest)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(endpoint)
-
+                        
                         // Then
                         let receivedURLRequest = networkSessionSpy.receivedURLRequest
-                        XCTAssertEqual(
-                                receivedURLRequest?.url?.path(),
-                                endpoint.path
-                        )
-
+                        #expect(receivedURLRequest?.url?.path() == endpoint.path)
+                        
                         if let receivedHTTPBody = receivedURLRequest?.httpBody {
                                 if let receivedBody = try? JSONDecoder().decode(StubRequest.self, from: receivedHTTPBody) {
-                                        XCTAssertEqual(
-                                                receivedBody,
-                                                encodableRequest
-                                        )
+                                        #expect(receivedBody == encodableRequest)
                                 } else {
-                                        XCTFail("Failed to decode HTTPBody into ValidEncodableRequest.")
+                                        Issue.record("Failed to decode HTTPBody into ValidEncodableRequest.")
                                 }
                         } else {
-                                XCTFail("Expected HTTPBody, got nil instead.")
+                                Issue.record("Expected HTTPBody, got nil instead.")
                         }
-
-                        XCTAssertEqual(
-                                receivedURLRequest?.value(forHTTPHeaderField: HTTPHeader.Key.contentType),
-                                HTTPHeader.Value.applicationJSON
-                        )
+                        
+                        #expect(receivedURLRequest?.value(forHTTPHeaderField: HTTPHeader.Key.contentType) == HTTPHeader.Value.applicationJSON)
                 } catch {
-                        XCTFail("Expected success, got \(error) instead.")
+                        Issue.record("Expected success, got \(error) instead.")
                 }
         }
-
-        func test_whenEndpointBodyIsQueryParameter_requestHasCorrectQueryItems() async {
+        
+        @Test("When endpoint body is query parameter, request has correct query items")
+        func testQueryParameter() async {
                 // Given
                 let queryItemSorting: (URLQueryItem, URLQueryItem) -> Bool = { $0.name < $1.name }
                 let queryParameters: [String: String?] = [
@@ -318,33 +221,31 @@ final class NetworkProviderImplementationTests: XCTestCase {
                         "parameterWithNoValue": nil,
                 ]
                 let expectedQueryParameters =
-                        queryParameters
+                queryParameters
                         .map(URLQueryItem.init)
                         .sorted(by: queryItemSorting)
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.queryParametersEndpoint(queryParameters))
-
+                        
                         if let receivedURLRequest = networkSessionSpy.receivedURLRequest {
                                 // Then
                                 let receivedQueryParameters = getQueryItems(from: receivedURLRequest)
                                         .sorted(by: queryItemSorting)
-                                XCTAssertEqual(
-                                        receivedQueryParameters,
-                                        expectedQueryParameters
-                                )
+                                #expect(receivedQueryParameters == expectedQueryParameters)
                         } else {
-                                XCTFail("Expected URLRequest, got nil instead.")
+                                Issue.record("Expected URLRequest, got nil instead.")
                         }
                 } catch {
-                        XCTFail("doesn't matter error \(error)")
+                        Issue.record("doesn't matter error \(error)")
                 }
         }
-
-        func test_whenEndpointHasCustomHeaders_requestHasCorrectHeaders() async {
+        
+        @Test("When endpoint has custom headers, request has correct headers")
+        func testHeaders() async {
                 // Given
                 let queryParameters: [String: String?] = [
                         "query": "value"
@@ -352,23 +253,21 @@ final class NetworkProviderImplementationTests: XCTestCase {
                 let expectedHeaders = StubEndpoint.queryParametersEndpoint(queryParameters).headers
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.queryParametersEndpoint(queryParameters))
-
+                        
                         // Then
                         let receivedURLRequest = networkSessionSpy.receivedURLRequest
-                        XCTAssertEqual(
-                                receivedURLRequest?.allHTTPHeaderFields,
-                                expectedHeaders
-                        )
+                        #expect(receivedURLRequest?.allHTTPHeaderFields == expectedHeaders)
                 } catch {
-                        XCTFail("Expected success, got error \(error) instead.")
+                        Issue.record("Expected success, got error \(error) instead.")
                 }
         }
-
-        func test_whenEndpointHasCustomPath_requestHasCorrectPath() async {
+        
+        @Test("When endpoint has custom path, request has correct path")
+        func testCustomPath() async {
                 // Given
                 let queryParameters: [String: String?] = [
                         "key": "value"
@@ -376,69 +275,61 @@ final class NetworkProviderImplementationTests: XCTestCase {
                 let endpoint = StubEndpoint.queryParametersEndpoint(queryParameters)
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(endpoint)
-
+                        
                         // Then
                         let receivedURLRequest = networkSessionSpy.receivedURLRequest
-                        XCTAssertEqual(
-                                receivedURLRequest?.url?.path(),
-                                endpoint.path
-                        )
+                        #expect(receivedURLRequest?.url?.path() == endpoint.path)
                 } catch {
-                        XCTFail("Expected success, got error \(error) instead.")
+                        Issue.record("Expected success, got error \(error) instead.")
                 }
         }
-
-        func test_networkProviderSetsCorrectHTTPMethodFromEndpointInURLRequest() async {
+        
+        @Test("Network Provider sets correct HTTP method from endpoint in URL request")
+        func testHTTPMethod() async {
                 // Given
                 let networkSessionSpy = NetworkSessionSpy.fixture()
                 let sut = NetworkProviderImplementation(networkSession: networkSessionSpy)
-
+                
                 do {
                         // When
                         let _: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
                         let receivedGetURLRequest = networkSessionSpy.receivedURLRequest
                         let _: StubInstance1 = try await sut.request(StubEndpoint.postEndpoint)
                         let receivedPostURLRequest = networkSessionSpy.receivedURLRequest
-
+                        
                         // Then
-                        XCTAssertEqual(
-                                receivedGetURLRequest?.httpMethod,
-                                HTTPMethod.get.rawValue
-                        )
-                        XCTAssertEqual(
-                                receivedPostURLRequest?.httpMethod,
-                                HTTPMethod.post.rawValue
-                        )
+                        #expect(receivedGetURLRequest?.httpMethod == HTTPMethod.get.rawValue)
+                        #expect(receivedPostURLRequest?.httpMethod == HTTPMethod.post.rawValue)
                 } catch {
-                        XCTFail("Expected success, got error \(error) instead.")
+                        Issue.record("Expected success, got error \(error) instead.")
                 }
         }
-
-        func test_networkProviderDecodesExpectedResponse() async {
+        
+        @Test("Network provider decodes expected response")
+        func testDecodeResponse() async {
                 // Given
                 let expectedInstance = StubInstance1.fixture()
                 let sut = NetworkProviderImplementation(networkSession: NetworkSessionSpy.fixture())
-
+                
                 do {
                         // When
                         let receivedInstance: StubInstance1 = try await sut.request(StubEndpoint.getEndpoint)
-
+                        
                         // Then
-                        XCTAssertEqual(
-                                receivedInstance,
-                                expectedInstance
-                        )
+                        #expect(receivedInstance == expectedInstance)
                 } catch {
-                        XCTFail("Expected success, got error \(error) instead.")
+                        Issue.record("Expected success, got error \(error) instead.")
                 }
         }
+}
 
-        // MARK: - Utility methods
-        func getQueryItems(from request: URLRequest) -> [URLQueryItem] {
+// MARK: - Helpers
+extension NetworkProviderImplementationProcessingTests {
+        private func getQueryItems(from request: URLRequest) -> [URLQueryItem] {
                 guard
                         let url = request.url,
                         let components = URLComponents(
@@ -449,7 +340,7 @@ final class NetworkProviderImplementationTests: XCTestCase {
                 else {
                         return .init()
                 }
-
+                
                 return queryItems
         }
 }

--- a/Tests/InfrastructureNetworkTests/Spies/NetworkSessionSpy.swift
+++ b/Tests/InfrastructureNetworkTests/Spies/NetworkSessionSpy.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 @testable import InfrastructureNetwork
 
 final class NetworkSessionSpy: NetworkSession {


### PR DESCRIPTION
- Propagate NetworkProviderError correctly
- Migrate to swift-testing